### PR TITLE
Removed Babel options from Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,10 +19,7 @@ module.exports = (env, argv) => {
                     exclude: /node_modules/,
                     use: [
                         {
-                            loader: 'babel-loader',
-                            options: {
-                                presets: ['@babel/preset-env', '@babel/preset-react']
-                            }
+                            loader: 'babel-loader'
                         },
                         'eslint-loader'
                     ]


### PR DESCRIPTION
Options override default config file settings. 